### PR TITLE
Add ACLs, change inter-broker security protocol to SASL_SSL

### DIFF
--- a/acl-add.yml
+++ b/acl-add.yml
@@ -1,0 +1,24 @@
+- name: Update ACLs
+  hosts: as-broker-0-eu-west-1a
+  vars:
+    zk_hostname: as-zookeeper-0-eu-west-1a
+    user: ANONYMOUS
+    topic: anonymous
+
+  tasks:
+    - name: Add access to topic
+      shell: >
+        cp/confluent-3.3.1/bin/kafka-acls
+        --authorizer-properties zookeeper.connect={{ zk_hostname }}:2181
+        --add --allow-principal User:{{ user }}
+        --topic {{ topic }} --operation Read --operation Write --operation Describe
+      ignore_errors: yes
+
+    - name: Add access to create topics
+      shell: >
+        cp/confluent-3.3.1/bin/kafka-acls
+        --authorizer-properties zookeeper.connect={{ zk_hostname }}:2181
+        --add --allow-principal User:{{ user }}
+        --cluster --operation Create
+      ignore_errors: yes
+

--- a/acl-remove.yml
+++ b/acl-remove.yml
@@ -6,15 +6,6 @@
     topic: anonymous
 
   tasks:
-    - name: Add access to topic
-      shell: >
-        cp/confluent-3.3.1/bin/kafka-acls
-        --authorizer-properties zookeeper.connect={{ zk_hostname }}:2181
-        --add --allow-principal User:{{ user }}
-        --topic {{ topic }} --operation Read --operation Write --operation Describe
-      when: op == "allow"
-      ignore_errors: yes
-
     - name: Remove access to topic
       shell: >
         cp/confluent-3.3.1/bin/kafka-acls
@@ -22,6 +13,14 @@
         --remove --allow-principal User:{{ user }}
         --topic {{ topic }} --operation Read --operation Write --operation Describe
         --force
-      when: op == "deny"
+      ignore_errors: yes
+
+    - name: Remove access to create topics
+      shell: >
+        cp/confluent-3.3.1/bin/kafka-acls
+        --authorizer-properties zookeeper.connect={{ zk_hostname }}:2181
+        --remove --allow-principal User:{{ user }}
+        --cluster --operation Create
+        --force
       ignore_errors: yes
 

--- a/acl-setup.yml
+++ b/acl-setup.yml
@@ -11,6 +11,8 @@
     user_connect: connect
     user_c3: c3
     user_anonymous: ANONYMOUS
+    user_kerberos_broker: kafka
+    user_kerberos_client: client
 
   tasks:
     - name: ACLs for admin and broker (all access)
@@ -24,6 +26,7 @@
       with_items:
         - "{{ user_broker }}"
         - "{{ user_admin }}"
+        - "{{ user_kerberos_broker }}"
       ignore_errors: yes
 
     - name: Replicator ACLs (produce/consume access to all topics)
@@ -61,6 +64,7 @@
         - "{{ user_readonly }}"
         - "{{ user_singlereader }}"
         - "{{ user_c3 }}"
+        - "{{ user_kerberos_client }}"
       ignore_errors: yes
 
     - name: Allow access to everyone for performance topics

--- a/acl-setup.yml
+++ b/acl-setup.yml
@@ -1,0 +1,79 @@
+- name: setup ACLs
+  hosts: as-broker-0-eu-west-1a
+  vars:
+    zk_hostname: as-zookeeper-0-eu-west-1a
+    user_broker: broker
+    user_admin: admin
+    user_perf: perf
+    user_proof: proof
+    user_readonly: readonly
+    user_singlereader: singlereader
+    user_connect: connect
+    user_c3: c3
+    user_anonymous: ANONYMOUS
+
+  tasks:
+    - name: ACLs for admin and broker (all access)
+      shell: >
+        cp/confluent-3.3.1/bin/kafka-acls
+        --authorizer-properties zookeeper.connect={{ zk_hostname }}:2181
+        --add --allow-principal User:{{ item }}
+        --topic=* --group=* --transactional-id=* --cluster > acl-{{ item }}.out
+      args:
+        creates: acl-{{ item }}.out
+      with_items:
+        - "{{ user_broker }}"
+        - "{{ user_admin }}"
+      ignore_errors: yes
+
+    - name: Replicator ACLs (produce/consume access to all topics)
+      shell: >
+        cp/confluent-3.3.1/bin/kafka-acls
+        --authorizer-properties zookeeper.connect={{ zk_hostname }}:2181
+        --add --allow-principal User:{{ user_connect }}
+        --producer --consumer --topic=* --group=* --transactional-id=* > acl-connect.out
+      args:
+        creates: acl-connect.out
+      ignore_errors: yes
+
+    - name: ACLs for anonymous user (produce/consume access to anonymous topic/group) # TODO restrict host
+      shell: >
+        cp/confluent-3.3.1/bin/kafka-acls
+        --authorizer-properties zookeeper.connect={{ zk_hostname }}:2181
+        --add --allow-principal User:{{ user_anonymous }}
+        --topic anonymous --group anonymous --allow-host '*'
+        --producer --consumer > acl-anonymous.out
+      args:
+        creates: acl-anonymous.out
+      ignore_errors: yes
+
+    - name: Other users # TODO: Do we want to restrict these to specified topics?
+      shell: >
+        cp/confluent-3.3.1/bin/kafka-acls
+        --authorizer-properties zookeeper.connect={{ zk_hostname }}:2181
+        --add --allow-principal User:{{ item }}
+        --producer --consumer --topic=* --group=* --transactional-id=* > acl-{{ item }}.out
+      args:
+        creates: acl-{{ item }}.out
+      with_items:
+        - "{{ user_perf }}"
+        - "{{ user_proof }}"
+        - "{{ user_readonly }}"
+        - "{{ user_singlereader }}"
+        - "{{ user_c3 }}"
+      ignore_errors: yes
+
+    - name: Allow access to everyone for performance topics
+      shell: >
+        cp/confluent-3.3.1/bin/kafka-acls
+        --authorizer-properties zookeeper.connect={{ zk_hostname }}:2181
+        --add --allow-principal User:*
+        --topic={{ item }} > acl-{{ item }}.out
+      args:
+        creates: acl-{{ item }}.out
+      with_items:
+        - "r.slow-producer"
+        - "r.perf-10"
+        - "ireland_r.perf-10"
+      ignore_errors: yes
+

--- a/acl-update.yml
+++ b/acl-update.yml
@@ -1,0 +1,27 @@
+- name: Update ACLs
+  hosts: as-broker-0-eu-west-1a
+  vars:
+    zk_hostname: as-zookeeper-0-eu-west-1a
+    user: ANONYMOUS
+    topic: anonymous
+
+  tasks:
+    - name: Add access to topic
+      shell: >
+        cp/confluent-3.3.1/bin/kafka-acls
+        --authorizer-properties zookeeper.connect={{ zk_hostname }}:2181
+        --add --allow-principal User:{{ user }}
+        --topic {{ topic }} --operation Read --operation Write --operation Describe
+      when: op == "allow"
+      ignore_errors: yes
+
+    - name: Remove access to topic
+      shell: >
+        cp/confluent-3.3.1/bin/kafka-acls
+        --authorizer-properties zookeeper.connect={{ zk_hostname }}:2181
+        --remove --allow-principal User:{{ user }}
+        --topic {{ topic }} --operation Read --operation Write --operation Describe
+        --force
+      when: op == "deny"
+      ignore_errors: yes
+

--- a/roles/kafka/tasks/main.yml
+++ b/roles/kafka/tasks/main.yml
@@ -66,9 +66,9 @@
         advertised.listeners=PLAINTEXT://{{ public['dns'] }}:{{kafka.ports.plain}},SASL_SSL://{{ public['dns'] }}:{{kafka.ports.sasl_ssl}},SASL_PLAINTEXT://{{ public['dns'] }}:{{kafka.ports.sasl_plaintext}},SSL://{{ public['dns'] }}:{{kafka.ports.ssl}}
         
         # SASL_PLAINTEXT (or SASL_SSL, PLAINTEXT, SSL)
-        #security.inter.broker.protocol=SASL_SSL
+        security.inter.broker.protocol=SASL_SSL
         # GSSAPI (or PLAIN)
-        #sasl.mechanism.inter.broker.protocol=PLAIN
+        sasl.mechanism.inter.broker.protocol=PLAIN
         
         sasl.enabled.mechanisms=PLAIN
 
@@ -89,6 +89,7 @@
         ssl.truststore.password={{kafka.store_password}}
         ssl.key.password={{kafka.store_password}}
         # super.users=User:CN=kafka.example.com,OU=,O=Confluent,L=London,ST=London,C=GB
+        authorizer.class.name=kafka.security.auth.SimpleAclAuthorizer
 
 - name: run broker
   command: >

--- a/roles/zk/tasks/main.yml
+++ b/roles/zk/tasks/main.yml
@@ -44,5 +44,5 @@
 # Simply passing the JAAS config doesn't mean it's required
 - name: run zk
   command: >
-    env KAFKA_OPTS="-Djava.security.auth.login.config=zookeeper_jaas.conf -Dlog4j.debug"" 
+    env KAFKA_OPTS="-Djava.security.auth.login.config=zookeeper_jaas.conf -Dlog4j.debug"
     cp/confluent-3.3.1/bin/zookeeper-server-start -daemon cp/confluent-3.3.1/etc/kafka/zookeeper.properties


### PR DESCRIPTION
- The ACLs may need tweaking depending on what each user should be allowed.
- Had to switch inter-broker security protocol to  SASL so that PLAINTEXT ACLs could be restrictive.
- The hostnames set in acl-setup.yml were copied from topic-setup.yml.